### PR TITLE
Add default_labels with ref_uuid

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,7 @@
 provider "google" {
   project = "project"
   region  = "europe-west1"
+  default_labels = {
+    ref_uuid = var.ref_uuid
+  }
 }


### PR DESCRIPTION
This PR adds `ref_uuid` to the default_labels block in the google provider.