### PR TITLE
Add default_labels with ref_uuid

### DIFF
--- a/modules/gcp/provider.tf
+++ b/modules/gcp/provider.tf
@@ -1,7 +1,8 @@
 provider "google" {
   project = "project"
   region  = "europe-west1"
-    default_labels = {
-      env="prod"
+  default_labels = {
+    env      = "prod"
+    ref_uuid = var.ref_uuid
   }
 }


### PR DESCRIPTION
This PR adds `ref_uuid` to the default_labels block in the google provider.